### PR TITLE
Trying to add Windows support. Using dnspython library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+requests
 requests_futures==0.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+dnspython
 requests
 requests_futures==0.9.9


### PR DESCRIPTION
I've had a go at adding Windows support to this tool. I used a python library [dnspython](https://pypi.org/project/dnspython/) to replace the use of the `host` command through the shell for doing DNS lookups. I get identical results between running on Linux using `host` and running on Windows with the library.

``` python
res = resolver.Resolver()
res.nameservers = [nameserver]

for name in names:
	try:
		res.query(name)
		# If no exception is thrown, save it as a valid DNS name and send to callback
		# if defined.
		valid_names.append(name)
		if callback:
			callback(name)
	except:
		# Name cannot be found, continue
		pass 
```

Performance is bad, I've not implemented any threading currently. The dnspython library is listed as thread safe but I'm not sure what the cleanest way to add some threading or async running support would be given the different levels of support for things like async across Python versions.

At the moment there's a little switch at the start of `fast_dns_lookup` which checks the OS version, and if its Windows redirects to the `python_dns_lookup` implementation.

``` python
# If we are running on windows use the python dns library instead
if os.name == 'nt':
    return python_dns_lookup(names, nameserver, callback)
```

There's also a minor fix that **requests** is missing from `requirements.txt` currently.

Big fan of the tool, it's been really useful to audit some of my sites. Really easy to use.