### PR TITLE
Make doc more coherent

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Keywords are mutated automatically using strings from `enum_tools/fuzz.txt` or a
 Let's say you were researching "somecompany" whose website is "somecompany.io" that makes a product called "blockchaindoohickey". You could run the tool like this:
 
 ```sh
-cloudenum.py -k somecompany -k somecompany.io -k blockchaindoohickey
+./cloud_enum.py -k somecompany -k somecompany.io -k blockchaindoohickey
 ```
 
 HTTP scraping and DNS lookups use 5 threads each by default. You can try increasing this, but eventually the cloud providers will rate limit you. Here is an example to increase to 10.
 
 ```sh
-cloudenum.py -k keyword -t 10
+./cloud_enum.py -k keyword -t 10
 ```
 
 **IMPORTANT**: Some resources (Azure Containers, GCP Functions) are discovered per-region. To save time scanning, there is a "REGIONS" variable defined in `cloudenum/azure_regions.py and cloudenum/gcp_regions.py` that is set by default to use only 1 region. You may want to look at these files and edit them to be relevant to your own work.


### PR DESCRIPTION
Just a bit of improvement for any future reader. At few places, the command has been mentioned `cloudenum.py` but there's an underscore in the actual script. I miss it every time!