### PR TITLE
GCP length check

### DIFF
--- a/enum_tools/gcp_checks.py
+++ b/enum_tools/gcp_checks.py
@@ -331,9 +331,16 @@ def check_functions(names, brute_list, quickscan, threads):
     print(f"[*] Testing across {len(regions)} regions defined in the config file")
 
     # Take each mutated keyword craft a url with the correct format
+    ## Below added by dnx
     for region in regions:
-        candidates += [region + '-' + name + '.' + FUNC_URL for name in names]
-
+        for name in names:
+            if len(name) < 254:
+                newdomain = f"{region}-{name}.{FUNC_URL}"
+                portions = newdomain.split(".")
+                for portion in portions:
+                    if len(portion) < 65:
+                        candidates.append(newdomain)
+                
     # Send the valid names to the batch HTTP processor
     utils.get_url_batch(candidates, use_ssl=False,
                         callback=print_functions_response1,

--- a/enum_tools/gcp_checks.py
+++ b/enum_tools/gcp_checks.py
@@ -331,15 +331,17 @@ def check_functions(names, brute_list, quickscan, threads):
     print(f"[*] Testing across {len(regions)} regions defined in the config file")
 
     # Take each mutated keyword craft a url with the correct format
-    ## Below added by dnx
+    toolong = False
     for region in regions:
         for name in names:
-            if len(name) < 254:
-                newdomain = f"{region}-{name}.{FUNC_URL}"
-                portions = newdomain.split(".")
-                for portion in portions:
-                    if len(portion) < 65:
-                        candidates.append(newdomain)
+            newdomain = f"{region}-{name}.{FUNC_URL}"
+            parts = newdomain.split(".")
+            for part in parts:
+                if len(part) > 63:
+                    toolong = True
+            if len(newdomain) < 254 and toolong is False:
+                candidates.append(newdomain)
+            toolong = False
                 
     # Send the valid names to the batch HTTP processor
     utils.get_url_batch(candidates, use_ssl=False,


### PR DESCRIPTION
Addresses issue #61 

This probably could do with a helper in utils.py, but this was my 'get it working' approach, not being overly familiar with the codebase.

Checking the URL before mutation doesn't solve the issue as the length blows out once the region, func_url added.

Other providers were fine, the only one I had fail (using default mutations) was this.