### PR TITLE
Program wasn't printing *.scm.azurewebsites.net sites when "Unauthorized" HTTP response reason is returned

### DIFF
--- a/enum_tools/azure_checks.py
+++ b/enum_tools/azure_checks.py
@@ -64,6 +64,7 @@ def print_account_response(reply):
         data['msg'] = 'Unathorized Account'
         data['target'] = reply.url
         data['access'] = 'public'
+        utils.fmt_output(data)
     else:
         print("    Unknown status codes being received from " + reply.url +":\n"
               "       "+ str(reply.status_code)+" : "+ reply.reason)


### PR DESCRIPTION
Program wasn't printing `*.scm.azurewebsites.net` sites when "Unauthorized" HTTP response reason is returned.

Simple fix, seems like it was initially intended.